### PR TITLE
fixed resign_linux.sh for Arch

### DIFF
--- a/resign_linux.sh
+++ b/resign_linux.sh
@@ -187,13 +187,17 @@ function ps3xploit_resign() {
     fi;
 
     # Check if python-dev is installed
-    python_headers=$(dpkg-query -l python-dev >/dev/null 2>&1; echo "${?}");
-    if [ "${python_headers}" -ne 0 ]; then
-      echo;
-      echo "ps3xploit_ps3py_all: 'python-dev' not is installed, exiting...";
-      echo "                     To continue install 'python-dev'";
-      echo;
-      return;
+    if [ $(cat /etc/os-release | grep 'ID_LIKE=') == 'ID_LIKE=arch' ]; then
+      continue;
+    else
+      python_headers=$(dpkg-query -l python-dev >/dev/null 2>&1; echo "${?}");
+      if [ "${python_headers}" -ne 0 ]; then
+        echo;
+        echo "ps3xploit_ps3py_all: 'python-dev' not is installed, exiting...";
+        echo "                     To continue install 'python-dev'";
+        echo;
+        return;
+      fi;
     fi;
 
     # Message output


### PR DESCRIPTION
Was not compiling on Arch and distributions based on it like Manjaro because python-dev is basically included in python because it's rolling release